### PR TITLE
Updated readme to include 'cxs.prefix' api function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ Returns the rendered CSS string for static and server-side rendering.
 
 Resets the cache for server-side rendering
 
+### `cxs.prefix(val)`
+
+Updates the default class name prefix with the value passed to this function.
+
 ### `cxs/component`
 
 A [styled-components][sc]-like API for creating React components with cxs.


### PR DESCRIPTION
'cxs.prefix' function was not documented and i have to go through the code to figure out the way to override default classname prefix, so documenting this in the readme.