### PR TITLE
Add benchmarks to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ coverage
 .travis.yml
 .babelrc
 webpack.config.js
+benchmarks


### PR DESCRIPTION
Prevent node_modules pollution by ignoring benchmarks.